### PR TITLE
Fix k600_extractor.sh: Rename files with spaces

### DIFF
--- a/k600_extractor.sh
+++ b/k600_extractor.sh
@@ -12,6 +12,7 @@ root_dl_targz="k600_targz"
 curr_dl=$root_dl_targz/train
 curr_extract=$root_dl/train
 [ ! -d $curr_extract ] && mkdir -p $curr_extract
+find $curr_dl -type f | while read file; do mv "$file" `echo $file | tr ' ' '_'` done
 tar_list=$(ls $curr_dl)
 for f in $tar_list
 do
@@ -22,6 +23,7 @@ done
 curr_dl=$root_dl_targz/val
 curr_extract=$root_dl/val
 [ ! -d $curr_extract ] && mkdir -p $curr_extract
+find $curr_dl -type f | while read file; do mv "$file" `echo $file | tr ' ' '_'` done
 tar_list=$(ls $curr_dl)
 for f in $tar_list
 do
@@ -32,6 +34,7 @@ done
 curr_dl=$root_dl_targz/test
 curr_extract=$root_dl/test
 [ ! -d $curr_extract ] && mkdir -p $curr_extract
+find $curr_dl -type f | while read file; do mv "$file" `echo $file | tr ' ' '_'` done
 tar_list=$(ls $curr_dl)
 for f in $tar_list
 do


### PR DESCRIPTION
This fix in k600_extractor.sh resolves #30 by replacing filenames containing spaces with underscores '_'