### PR TITLE
Update arrange_by_classes.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kinetics datasets
+# Kinetics Datasets Downloader
 
 Kinetics is a collection of large-scale, high-quality datasets of URL links of up to 650,000 video clips that cover 400/600/700 human action classes, depending on the dataset version. The videos include human-object interactions such as playing instruments, as well as human-human interactions such as shaking hands and hugging. Each action class has at least 400/600/700 video clips. Each clip is human annotated with a single action class and lasts around 10 seconds.
 

--- a/arrange_by_classes.py
+++ b/arrange_by_classes.py
@@ -19,7 +19,7 @@ def load_label(csv):
 
 def collect_dict(path, split, replace_videos):
     split_video_path = path / split
-    split_csv = load_label(path / f'{split}.csv')
+    split_csv = load_label(path / f'annotations/{split}.csv')
     split_videos = list(split_video_path.glob('*.mp4'))
     split_videos = {str(p.stem)[:11]:p for p in split_videos}
     # replace paths for corrupted videos


### PR DESCRIPTION
Path to the `{split}.cvs` is not correct.

Original:
```
split_csv = load_label(path / f'{split}.csv')
```

Updated to:
```
split_csv = load_label(path / f'annotations/{split}.csv')
```